### PR TITLE
psycopg 3.2.9 rebuild to release to main

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,6 +90,7 @@ outputs:
       requires:
         - pip
         - pytest
+        - pytest-asyncio
 
 about:
   home: https://psycopg.org/psycopg3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 2d32c406f1b8e628e0eafd8608b452872bd67576d9d269e25ffbcd4ebacae085
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<38]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -90,7 +90,7 @@ outputs:
       requires:
         - pip
         - pytest
-        - pytest-asyncio
+        - pytest-tornasync
 
 about:
   home: https://psycopg.org/psycopg3


### PR DESCRIPTION
psycopg 3.2.9 rebuild to release to main

**Destination channel:** Defaults

### Links

- [PKG-10382]
- dev_url:        https://github.com/langchain-ai/langgraph/tree/prebuilt==1.0.1
- conda_forge:    https://github.com/conda-forge/langgraph-prebuilt-feedstock
- pypi:           https://pypi.org/project/langgraph-prebuilt/1.0.1
- pypi inspector: https://inspector.pypi.io/project/langgraph-prebuilt/1.0.1

### Explanation of changes:

- psycopg 3.2.9 rebuild to release to main


[PKG-10382]: https://anaconda.atlassian.net/browse/PKG-10382?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ