### PR TITLE
rebuild psycopg against libpq 18.4

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,3 +1,0 @@
-# TODO: remove once conda_build_config.yaml pins libpq to 18.4
-libpq:
-  - '18.4'

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,3 @@
+# TODO: remove once conda_build_config.yaml pins libpq to 18.4
+libpq:
+  - '18.4'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: ca10f87344be1eadd81063d6a49b871d8a0ca779ccce8b8a2fc1acc4f4a0987a
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<310]
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ outputs:
         - setuptools >=80.3.1
         - wheel >=0.37
         - tomli >=2.0.1  # [py<311]
-        - libpq {{ libpq }}
+        - libpq 18.4  # TODO: revert to placeholder / remove once set via conda_build_config.yaml
       run:
         - python
         - libpq
@@ -57,7 +57,7 @@ outputs:
         - setuptools >=80.3.1
         - wheel >=0.37
         - pip
-        - libpq {{ libpq }}
+        - libpq 18.4  # TODO: revert to placeholder / remove once set via conda_build_config.yaml
       run:
         - python
         - backports.zoneinfo >=0.2.0  # [py<39]


### PR DESCRIPTION
## Rebuild psycopg against libpq 18.4

### Links
- Jira Ticket: [PKG-15953](https://anaconda.atlassian.net/browse/PKG-15953)

### Changes
- `recipe/meta.yaml`: pinned `libpq` to 18.4 directly (was `{{ libpq }}` placeholder) in both `psycopg-c` and `psycopg` outputs; bumped build number to 1

[PKG-15953]: https://anaconda.atlassian.net/browse/PKG-15953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ